### PR TITLE
Adds groups and a template for the Creative AI cluster

### DIFF
--- a/content/authors/Miguel González Duque/_index.md
+++ b/content/authors/Miguel González Duque/_index.md
@@ -14,7 +14,7 @@ role: PhD Student
 
 # Organizations/Affiliations
 organizations:
-- name: Creative AI Cluster
+- name: Creative AI Lab
   url: "/groups/creativeai"
 - name: IT University of Copenhagen
   url: "https://www.itu.dk/"

--- a/content/authors/Miguel González Duque/_index.md
+++ b/content/authors/Miguel González Duque/_index.md
@@ -14,18 +14,20 @@ role: PhD Student
 
 # Organizations/Affiliations
 organizations:
+- name: Creative AI Cluster
+  url: "/groups/creativeai"
 - name: IT University of Copenhagen
   url: "https://www.itu.dk/"
 
 # Short bio (displayed in user profile at end of posts)
-bio: My research interests include distributed robotics, mobile computing and programmable matter.
+bio: My work focuses on applications of Bayesian Statistics.
 
 interests:
-- Imitation learning
-- Deep learning
-- Player modelling
+- Machine Learning and AI
+- Statistical Modeling
+- Bayesian Statistics
 - Real-time strategy games
-- Machine learning and AI
+- Dynamic Difficulty Adjustment
 
 #education:
   #courses:
@@ -72,4 +74,4 @@ user_groups:
 - PhD Students
 ---
 
-Current research interests: Bayesian methods, Games for Rehabilitation, Reinforcement Learning, Adversarial Learning, Generative models, Procedural Content Generation, Computer Art and AI Ethics.
+Current research interests: Bayesian Statistics, Generative models, Procedural Content Generation and Computer Art.

--- a/content/groups/CreativeAI/index.md
+++ b/content/groups/CreativeAI/index.md
@@ -1,0 +1,43 @@
+---
+# Documentation: https://sourcethemes.com/academic/docs/managing-content/
+
+title: "Creative AI"
+summary: ""
+authors: [Sebastian Risi]
+tags: []
+categories: []
+date: 2021-01-01T12:49:51+01:00
+
+# Optional external URL for project (replaces project detail page).
+# external_link: "https://charming-etn.eu/"
+
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+# Focal points: Smart, Center, TopLeft, Top, TopRight, Left, Right, BottomLeft, Bottom, BottomRight.
+image:
+  caption: ""
+  focal_point: ""
+  preview_only: false
+
+# Custom links (optional).
+#   Uncomment and edit lines below to show custom links.
+# links:
+# - name: Follow
+#   url: https://twitter.com
+#   icon_pack: fab
+#   icon: twitter
+
+url_code: ""
+url_pdf: ""
+url_slides: ""
+url_video: ""
+
+# Slides (optional).
+#   Associate this project with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides = "example-slides"` references `content/slides/example-slides.md`.
+#   Otherwise, set `slides = ""`.
+slides: ""
+---
+
+Creative AI Cluster.

--- a/content/home/groups.md
+++ b/content/home/groups.md
@@ -1,0 +1,77 @@
++++
+# A Projects section created with the Portfolio widget.
+widget = "portfolio"  # See https://sourcethemes.com/academic/docs/page-builder/
+headless = false  # This file represents a page section.
+active = true  # Activate this widget? true/false
+weight = 45  # Order that this section will appear.
+
+title = "Groups"
+subtitle = ""
+
+[content]
+  # Page type to display. E.g. project.
+  page_type = "groups"
+
+  # Filter toolbar (optional).
+  # Add or remove as many filters (`[[content.filter_button]]` instances) as you like.
+  # To show all items, set `tag` to "*".
+  # To filter by a specific tag, set `tag` to an existing tag name.
+  # To remove toolbar, delete/comment all instances of `[[content.filter_button]]` below.
+
+  # Default filter index (e.g. 0 corresponds to the first `[[filter_button]]` instance below).
+  filter_default = 0
+
+  # [[content.filter_button]]
+  #   name = "All"
+  #   tag = "*"
+
+  # [[content.filter_button]]
+  #   name = "Deep Learning"
+  #   tag = "Deep Learning"
+
+  # [[content.filter_button]]
+  #   name = "Other"
+  #   tag = "Demo"
+
+[design]
+  # Choose how many columns the section has. Valid values: 1 or 2.
+  columns = "1"
+
+  # Toggle between the various page layout types.
+  #   1 = List
+  #   2 = Compact
+  #   3 = Card
+  #   5 = Showcase
+  view = 5
+
+  # For Showcase view, flip alternate rows?
+  flip_alt_rows = false
+
+[design.background]
+  # Apply a background color, gradient, or image.
+  #   Uncomment (by removing `#`) an option to apply it.
+  #   Choose a light or dark text color by setting `text_color_light`.
+  #   Any HTML color name or Hex value is valid.
+
+  # Background color.
+  # color = "navy"
+
+  # Background gradient.
+  # gradient_start = "DeepSkyBlue"
+  # gradient_end = "SkyBlue"
+
+  # Background image.
+  # image = "background.jpg"  # Name of image in `static/media/`.
+  # image_darken = 0.6  # Darken the image? Range 0-1 where 0 is transparent and 1 is opaque.
+
+  # Text color (true=light or false=dark).
+  # text_color_light = true  
+
+[advanced]
+ # Custom CSS. 
+ css_style = ""
+
+ # CSS class.
+ css_class = ""
++++
+

--- a/content/home/people.md
+++ b/content/home/people.md
@@ -13,10 +13,11 @@ subtitle = ""
 [content]
   # Choose which groups/teams of users to display.
   #   Edit `user_groups` in each user's profile to add them to one or more of these groups.
-  user_groups = ["Head of Center", "Principal Investigators",
+  user_groups = ["Head of Center",
+                 "Principal Investigators",
                  "Professors",
                  "Postdoctoral Researchers",
-				 "PhD Students",
+                 "PhD Students",
                  "Research Assistants",
                  "Visitors",
                  "Alumni"]


### PR DESCRIPTION
Hey, Dom. 

I added a "Groups" section. We can link to them in the affiliations section of each user. The name and content is still to be debated. I wonder: is there a way of *not* rendering the section in the landing page? I should check the documentation more carefully.

Cheers.